### PR TITLE
Update and testing to Severity formatter for GCP Logging formats

### DIFF
--- a/severity_formatter.go
+++ b/severity_formatter.go
@@ -31,7 +31,7 @@ func (f *SeverityFormatter) Format(entry *Entry) ([]byte, error) {
 	}
 
 	data["time"] = entry.Time.Format(timestampFormat)
-	data["msg"] = entry.Message
+	data["message"] = entry.Message
 	data["level"] = entry.Level.String()
 	data["severity"] = strings.ToUpper(entry.Level.String())
 

--- a/severity_formatter_test.go
+++ b/severity_formatter_test.go
@@ -1,11 +1,30 @@
 package logrus
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 
+	"github.com/stretchr/testify/assert"
+
 	"testing"
 )
+
+func LogAndAssertSeverityJSON(t *testing.T, log func(*Logger), assertions func(fields Fields)) {
+	var buffer bytes.Buffer
+	var fields Fields
+
+	logger := New()
+	logger.Out = &buffer
+	logger.Formatter = new(SeverityFormatter)
+
+	log(logger)
+
+	err := json.Unmarshal(buffer.Bytes(), &fields)
+	assert.Nil(t, err)
+
+	assertions(fields)
+}
 
 func TestSeverityErrorNotLost(t *testing.T) {
 	formatter := &SeverityFormatter{}
@@ -117,4 +136,32 @@ func TestSeverityEntryEndsWithNewline(t *testing.T) {
 	if b[len(b)-1] != '\n' {
 		t.Fatal("Expected Severity log entry to end with a newline")
 	}
+}
+
+func TestSeverityPrint(t *testing.T) {
+	LogAndAssertSeverityJSON(t, func(log *Logger) {
+		log.Print("test")
+	}, func(fields Fields) {
+		assert.Equal(t, fields["message"], "test")
+		assert.Equal(t, fields["level"], "info")
+	})
+}
+
+func TestSeverityInfo(t *testing.T) {
+	LogAndAssertSeverityJSON(t, func(log *Logger) {
+		log.Info("test")
+	}, func(fields Fields) {
+		t.Logf("fields: %#v", fields)
+		assert.Equal(t, fields["message"], "test")
+		assert.Equal(t, fields["level"], "info")
+	})
+}
+
+func TestSeverityWarn(t *testing.T) {
+	LogAndAssertSeverityJSON(t, func(log *Logger) {
+		log.Warn("test")
+	}, func(fields Fields) {
+		assert.Equal(t, fields["message"], "test")
+		assert.Equal(t, fields["level"], "warning")
+	})
 }


### PR DESCRIPTION
Changes the default json field for the Entry's message from `msg` to `message`. This is the format that Google Cloud Platform's logging expects and will expand cleanly in the Stackdriver Logging UI.

Tested in GCP and add some tests to verify formatting locally.